### PR TITLE
如果依赖的是运行时以外的，不打入 share AssetBundle包

### DIFF
--- a/Assets/YooAsset/Editor/AssetBundleBuilder/BuildAssetInfo.cs
+++ b/Assets/YooAsset/Editor/AssetBundleBuilder/BuildAssetInfo.cs
@@ -185,10 +185,13 @@ namespace YooAsset.Editor
 
 				if (_referenceBundleNames.Count > 1)
 				{
-					IPackRule packRule = PackDirectory.StaticPackRule;
-					var bundleName = packRule.GetBundleName(new PackRuleData(AssetPath));
-					var shareBundleName = $"share_{bundleName}.{YooAssetSettingsData.Setting.AssetBundleFileVariant}";
-					_shareBundleName = EditorTools.GetRegularPath(shareBundleName).ToLower();
+					if (!AssetPath.Contains("/Editor/") && !AssetPath.Contains("/Gizmos/"))
+					{
+						IPackRule packRule = PackDirectory.StaticPackRule;
+						var bundleName = packRule.GetBundleName(new PackRuleData(AssetPath));
+						var shareBundleName = $"share_{bundleName}.{YooAssetSettingsData.Setting.AssetBundleFileVariant}";
+						_shareBundleName = EditorTools.GetRegularPath(shareBundleName).ToLower();
+					}
 				}
 			}
 			else


### PR DESCRIPTION
share 会引入一些无关的依赖，这里是否能去掉？