### PR TITLE
判断分组不激活时，则不进行 CheckConfigError 的检测

### DIFF
--- a/Assets/YooAsset/Editor/AssetBundleCollector/AssetBundleCollectorGroup.cs
+++ b/Assets/YooAsset/Editor/AssetBundleCollector/AssetBundleCollectorGroup.cs
@@ -43,7 +43,10 @@ namespace YooAsset.Editor
 		{
 			if (AssetBundleCollectorSettingData.HasActiveRuleName(ActiveRuleName) == false)
 				throw new Exception($"Invalid {nameof(IActiveRule)} class type : {ActiveRuleName} in group : {GroupName}");
-
+			
+			// 当分组不是激活状态时，直接不进行检测
+			if (ActiveRuleName == nameof(DisableGroup)) return;
+			
 			foreach (var collector in Collectors)
 			{
 				collector.CheckConfigError();


### PR DESCRIPTION
这边可以补一个判定，仅检测激活分组 （不管 Disabled 分组资源有效无效），也可以增加检测效率，不然 Simulate 模式或打包时，会检测到 Disabled 的分组中有无效路径，则会没办法执行，反正我有重新 Enabled 分组后下次会检查到。