### PR TITLE
feat : add load scene parameter LocalPhysicsMode

### DIFF
--- a/Assets/YooAsset/Runtime/ResourceManager/Provider/BundledSceneProvider.cs
+++ b/Assets/YooAsset/Runtime/ResourceManager/Provider/BundledSceneProvider.cs
@@ -8,13 +8,14 @@ namespace YooAsset
 {
     internal sealed class BundledSceneProvider : ProviderOperation
     {
-        public readonly LoadSceneMode SceneMode;
+        public LoadSceneMode SceneMode => LoadSceneParams.loadSceneMode;
+        public readonly LoadSceneParameters LoadSceneParams;
         private AsyncOperation _asyncOperation;
         private bool _suspendLoadMode;
 
-        public BundledSceneProvider(ResourceManager manager, string providerGUID, AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad) : base(manager, providerGUID, assetInfo)
+        public BundledSceneProvider(ResourceManager manager, string providerGUID, AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad, LocalPhysicsMode physicsMode = default) : base(manager, providerGUID, assetInfo)
         {
-            SceneMode = sceneMode;
+            LoadSceneParams = new LoadSceneParameters(sceneMode, physicsMode);
             SceneName = Path.GetFileNameWithoutExtension(assetInfo.AssetPath);
             _suspendLoadMode = suspendLoad;
         }
@@ -61,15 +62,14 @@ namespace YooAsset
                 if (IsWaitForAsyncComplete)
                 {
                     // 注意：场景同步加载方法不会立即加载场景，而是在下一帧加载。
-                    LoadSceneParameters parameters = new LoadSceneParameters(SceneMode);
-                    SceneObject = SceneManager.LoadScene(MainAssetInfo.AssetPath, parameters);
+                    SceneObject = SceneManager.LoadScene(MainAssetInfo.AssetPath, LoadSceneParams);
                     _steps = ESteps.Checking;
                 }
                 else
                 {
                     // 注意：如果场景不存在异步加载方法返回NULL
                     // 注意：即使是异步加载也要在当帧获取到场景对象
-                    _asyncOperation = SceneManager.LoadSceneAsync(MainAssetInfo.AssetPath, SceneMode);
+                    _asyncOperation = SceneManager.LoadSceneAsync(MainAssetInfo.AssetPath, LoadSceneParams);
                     if (_asyncOperation != null)
                     {
                         _asyncOperation.allowSceneActivation = !_suspendLoadMode;

--- a/Assets/YooAsset/Runtime/ResourceManager/Provider/DatabaseSceneProvider.cs
+++ b/Assets/YooAsset/Runtime/ResourceManager/Provider/DatabaseSceneProvider.cs
@@ -8,13 +8,14 @@ namespace YooAsset
 {
     internal sealed class DatabaseSceneProvider : ProviderOperation
     {
-        public readonly LoadSceneMode SceneMode;
+        public LoadSceneMode SceneMode => LoadSceneParams.loadSceneMode;
+        public readonly LoadSceneParameters LoadSceneParams;
         private bool _suspendLoadMode;
         private AsyncOperation _asyncOperation;
 
-        public DatabaseSceneProvider(ResourceManager manager, string providerGUID, AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad) : base(manager, providerGUID, assetInfo)
+        public DatabaseSceneProvider(ResourceManager manager, string providerGUID, AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad, LocalPhysicsMode physicsMode = default) : base(manager, providerGUID, assetInfo)
         {
-            SceneMode = sceneMode;
+            LoadSceneParams = new LoadSceneParameters(sceneMode, physicsMode);
             SceneName = Path.GetFileNameWithoutExtension(assetInfo.AssetPath);
             _suspendLoadMode = suspendLoad;
         }
@@ -53,14 +54,12 @@ namespace YooAsset
             {
                 if (IsWaitForAsyncComplete)
                 {
-                    LoadSceneParameters loadSceneParameters = new LoadSceneParameters(SceneMode);
-                    SceneObject = UnityEditor.SceneManagement.EditorSceneManager.LoadSceneInPlayMode(MainAssetInfo.AssetPath, loadSceneParameters);
+                    SceneObject = UnityEditor.SceneManagement.EditorSceneManager.LoadSceneInPlayMode(MainAssetInfo.AssetPath, LoadSceneParams);
                     _steps = ESteps.Checking;
                 }
                 else
                 {
-                    LoadSceneParameters loadSceneParameters = new LoadSceneParameters(SceneMode);
-                    _asyncOperation = UnityEditor.SceneManagement.EditorSceneManager.LoadSceneAsyncInPlayMode(MainAssetInfo.AssetPath, loadSceneParameters);
+                    _asyncOperation = UnityEditor.SceneManagement.EditorSceneManager.LoadSceneAsyncInPlayMode(MainAssetInfo.AssetPath, LoadSceneParams);
                     if (_asyncOperation != null)
                     {
                         _asyncOperation.allowSceneActivation = !_suspendLoadMode;

--- a/Assets/YooAsset/Runtime/ResourceManager/ResourceManager.cs
+++ b/Assets/YooAsset/Runtime/ResourceManager/ResourceManager.cs
@@ -86,7 +86,7 @@ namespace YooAsset
         /// 注意：返回的场景句柄是唯一的，每个场景句柄对应自己的场景提供者对象。
         /// 注意：业务逻辑层应该避免同时加载一个子场景。
         /// </summary>
-        public SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad, uint priority)
+        public SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode, bool suspendLoad, uint priority, LocalPhysicsMode physicsMode = default)
         {
             if (assetInfo.IsInvalid)
             {
@@ -107,9 +107,9 @@ namespace YooAsset
             ProviderOperation provider;
             {
                 if (_simulationOnEditor)
-                    provider = new DatabaseSceneProvider(this, providerGUID, assetInfo, sceneMode, suspendLoad);
+                    provider = new DatabaseSceneProvider(this, providerGUID, assetInfo, sceneMode, suspendLoad, physicsMode);
                 else
-                    provider = new BundledSceneProvider(this, providerGUID, assetInfo, sceneMode, suspendLoad);
+                    provider = new BundledSceneProvider(this, providerGUID, assetInfo, sceneMode, suspendLoad, physicsMode);
                 provider.InitSpawnDebugInfo();
                 _providerDic.Add(providerGUID, provider);
                 OperationSystem.StartOperation(PackageName, provider);

--- a/Assets/YooAsset/Runtime/ResourcePackage/ResourcePackage.cs
+++ b/Assets/YooAsset/Runtime/ResourcePackage/ResourcePackage.cs
@@ -486,11 +486,11 @@ namespace YooAsset
         /// </summary>
         /// <param name="location">场景的定位地址</param>
         /// <param name="sceneMode">场景加载模式</param>
-        public SceneHandle LoadSceneSync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single)
+        public SceneHandle LoadSceneSync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckInitialize();
             AssetInfo assetInfo = ConvertLocationToAssetInfo(location, null);
-            return LoadSceneInternal(assetInfo, true, sceneMode, false, 0);
+            return LoadSceneInternal(assetInfo, true, sceneMode, false, 0, physicsMode);
         }
 
         /// <summary>
@@ -498,10 +498,10 @@ namespace YooAsset
         /// </summary>
         /// <param name="assetInfo">场景的资源信息</param>
         /// <param name="sceneMode">场景加载模式</param>
-        public SceneHandle LoadSceneSync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single)
+        public SceneHandle LoadSceneSync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckInitialize();
-            return LoadSceneInternal(assetInfo, true, sceneMode, false, 0);
+            return LoadSceneInternal(assetInfo, true, sceneMode, false, 0, physicsMode);
         }
 
         /// <summary>
@@ -511,11 +511,11 @@ namespace YooAsset
         /// <param name="sceneMode">场景加载模式</param>
         /// <param name="suspendLoad">场景加载到90%自动挂起</param>
         /// <param name="priority">加载的优先级</param>
-        public SceneHandle LoadSceneAsync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 0)
+        public SceneHandle LoadSceneAsync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 0, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckInitialize();
             AssetInfo assetInfo = ConvertLocationToAssetInfo(location, null);
-            return LoadSceneInternal(assetInfo, false, sceneMode, suspendLoad, priority);
+            return LoadSceneInternal(assetInfo, false, sceneMode, suspendLoad, priority, physicsMode);
         }
 
         /// <summary>
@@ -525,16 +525,16 @@ namespace YooAsset
         /// <param name="sceneMode">场景加载模式</param>
         /// <param name="suspendLoad">场景加载到90%自动挂起</param>
         /// <param name="priority">加载的优先级</param>
-        public SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 0)
+        public SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 0, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckInitialize();
-            return LoadSceneInternal(assetInfo, false, sceneMode, suspendLoad, priority);
+            return LoadSceneInternal(assetInfo, false, sceneMode, suspendLoad, priority, physicsMode);
         }
 
-        private SceneHandle LoadSceneInternal(AssetInfo assetInfo, bool waitForAsyncComplete, LoadSceneMode sceneMode, bool suspendLoad, uint priority)
+        private SceneHandle LoadSceneInternal(AssetInfo assetInfo, bool waitForAsyncComplete, LoadSceneMode sceneMode, bool suspendLoad, uint priority, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckAssetLoadType(assetInfo.AssetType);
-            var handle = _resourceManager.LoadSceneAsync(assetInfo, sceneMode, suspendLoad, priority);
+            var handle = _resourceManager.LoadSceneAsync(assetInfo, sceneMode, suspendLoad, priority, physicsMode);
             if (waitForAsyncComplete)
                 handle.WaitForAsyncComplete();
             return handle;

--- a/Assets/YooAsset/Runtime/YooAssetsExtension.cs
+++ b/Assets/YooAsset/Runtime/YooAssetsExtension.cs
@@ -161,10 +161,10 @@ namespace YooAsset
         /// </summary>
         /// <param name="location">场景的定位地址</param>
         /// <param name="sceneMode">场景加载模式</param>
-        public static SceneHandle LoadSceneSync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single)
+        public static SceneHandle LoadSceneSync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckDefaultPackageValid();
-            return _defaultPackage.LoadSceneSync(location, sceneMode);
+            return _defaultPackage.LoadSceneSync(location, sceneMode, physicsMode);
         }
 
         /// <summary>
@@ -172,10 +172,10 @@ namespace YooAsset
         /// </summary>
         /// <param name="assetInfo">场景的资源信息</param>
         /// <param name="sceneMode">场景加载模式</param>
-        public static SceneHandle LoadSceneSync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single)
+        public static SceneHandle LoadSceneSync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckDefaultPackageValid();
-            return _defaultPackage.LoadSceneSync(assetInfo, sceneMode);
+            return _defaultPackage.LoadSceneSync(assetInfo, sceneMode, physicsMode);
         }
 
         /// <summary>
@@ -185,10 +185,10 @@ namespace YooAsset
         /// <param name="sceneMode">场景加载模式</param>
         /// <param name="suspendLoad">场景加载到90%自动挂起</param>
         /// <param name="priority">优先级</param>
-        public static SceneHandle LoadSceneAsync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 100)
+        public static SceneHandle LoadSceneAsync(string location, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 100, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckDefaultPackageValid();
-            return _defaultPackage.LoadSceneAsync(location, sceneMode, suspendLoad, priority);
+            return _defaultPackage.LoadSceneAsync(location, sceneMode, suspendLoad, priority, physicsMode);
         }
 
         /// <summary>
@@ -198,10 +198,10 @@ namespace YooAsset
         /// <param name="sceneMode">场景加载模式</param>
         /// <param name="suspendLoad">场景加载到90%自动挂起</param>
         /// <param name="priority">优先级</param>
-        public static SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 100)
+        public static SceneHandle LoadSceneAsync(AssetInfo assetInfo, LoadSceneMode sceneMode = LoadSceneMode.Single, bool suspendLoad = false, uint priority = 100, LocalPhysicsMode physicsMode = default)
         {
             DebugCheckDefaultPackageValid();
-            return _defaultPackage.LoadSceneAsync(assetInfo, sceneMode, suspendLoad, priority);
+            return _defaultPackage.LoadSceneAsync(assetInfo, sceneMode, suspendLoad, priority, physicsMode);
         }
         #endregion
 


### PR DESCRIPTION
Added [LocalPhysicsMode](https://docs.unity3d.com/ScriptReference/SceneManagement.LocalPhysicsMode.html) parameter, used for per-scene physics simulation (local scene physics simulation) with [`PhysicsScene.Simulate`](https://docs.unity3d.com/2018.3/Documentation/ScriptReference/PhysicsScene.Simulate.html). Kept parameter as optional and converted field to get property for compatibility with existing projects.

Maybe also add [UnloadSceneOptions](https://docs.unity3d.com/ScriptReference/SceneManagement.UnloadSceneOptions.html)?