### PR TITLE
fix: 拷贝内置资源路径不正确

### DIFF
--- a/Assets/YooAsset/Samples~/Extension Sample/Runtime/ExtensionOperation/CopyBuildinManifestOperation.cs
+++ b/Assets/YooAsset/Samples~/Extension Sample/Runtime/ExtensionOperation/CopyBuildinManifestOperation.cs
@@ -129,13 +129,13 @@ public class CopyBuildinManifestOperation : GameAsyncOperation
     {
         string fileRoot = GetBuildinYooRoot();
         string fileName = YooAssetSettingsData.GetPackageHashFileName(_packageName, _packageVersion);
-        return PathUtility.Combine(fileRoot, fileName);
+        return PathUtility.Combine(fileRoot, _packageName, fileName);
     }
     private string GetBuildinManifestFilePath()
     {
         string fileRoot = GetBuildinYooRoot();
         string fileName = YooAssetSettingsData.GetManifestBinaryFileName(_packageName, _packageVersion);
-        return PathUtility.Combine(fileRoot, fileName);
+        return PathUtility.Combine(fileRoot, _packageName, fileName);
     }
 
     private string GetCacheYooRoot()
@@ -146,12 +146,12 @@ public class CopyBuildinManifestOperation : GameAsyncOperation
     {
         string fileRoot = GetCacheYooRoot();
         string fileName = YooAssetSettingsData.GetPackageHashFileName(_packageName, _packageVersion);
-        return PathUtility.Combine(fileRoot, fileName);
+        return PathUtility.Combine(fileRoot, _packageName, fileName);
     }
     private string GetCacheManifestFilePath()
     {
         string fileRoot = GetCacheYooRoot();
         string fileName = YooAssetSettingsData.GetManifestBinaryFileName(_packageName, _packageVersion);
-        return PathUtility.Combine(fileRoot, fileName);
+        return PathUtility.Combine(fileRoot, _packageName, fileName);
     }
 }


### PR DESCRIPTION
拷贝内置资源路径不正确，打包程序拷贝目录会携带包名文件夹一起拷贝，资源路径不是yoo/资源，应该为yoo/资源文件夹/资源