### PR TITLE
fix: 微信加密资源解密错误

### DIFF
--- a/Assets/YooAsset/Samples~/Extension Sample/Runtime/ExtensionFileSystem/WechatFileSystem/Operation/WXFSLoadBundleOperation.cs
+++ b/Assets/YooAsset/Samples~/Extension Sample/Runtime/ExtensionFileSystem/WechatFileSystem/Operation/WXFSLoadBundleOperation.cs
@@ -37,7 +37,7 @@ internal class WXFSLoadBundleOperation : FSLoadBundleOperation
             if (_webRequest == null)
             {
                 string mainURL = _fileSystem.RemoteServices.GetRemoteMainURL(_bundle.FileName);
-                _webRequest = WXAssetBundle.GetAssetBundle(mainURL);
+                _webRequest = _bundle.Encrypted ? UnityWebRequest.Get(mainURL) : WXAssetBundle.GetAssetBundle(mainURL);
                 _webRequest.SendWebRequest();
             }
 
@@ -59,11 +59,17 @@ internal class WXFSLoadBundleOperation : FSLoadBundleOperation
                 }
 
                 AssetBundle assetBundle;
-                var downloadHanlder = _webRequest.downloadHandler as DownloadHandlerWXAssetBundle;
+                
                 if (_bundle.Encrypted)
+                {
+                    var downloadHanlder = (DownloadHandlerBuffer)_webRequest.downloadHandler;
                     assetBundle = _fileSystem.LoadEncryptedAssetBundle(_bundle, downloadHanlder.data);
+                }
                 else
+                {
+                    var downloadHanlder = (DownloadHandlerWXAssetBundle)_webRequest.downloadHandler;
                     assetBundle = downloadHanlder.assetBundle;
+                }
 
                 if (assetBundle == null)
                 {


### PR DESCRIPTION
WXAssetBundle.GetAssetBundle返回的DownloadHandlerWXAssetBundle对象，FileData数组长度一直为0.