### PR TITLE
update parallel update bundle info only in UNITY_EDITOR

### DIFF
--- a/Assets/YooAsset/Editor/AssetBundleBuilder/BuildPipeline/BaseTasks/TaskUpdateBundleInfo.cs
+++ b/Assets/YooAsset/Editor/AssetBundleBuilder/BuildPipeline/BaseTasks/TaskUpdateBundleInfo.cs
@@ -3,20 +3,60 @@ using System.IO;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using UnityEditor;
 
-namespace YooAsset.Editor
-{
-    public abstract class TaskUpdateBundleInfo
-    {
-        public void UpdateBundleInfo(BuildContext context)
-        {
+namespace YooAsset.Editor {
+    public abstract class TaskUpdateBundleInfo {
+        public void UpdateBundleInfo(BuildContext context) {
             var buildParametersContext = context.GetContextObject<BuildParametersContext>();
             var buildMapContext = context.GetContextObject<BuildMapContext>();
             string pipelineOutputDirectory = buildParametersContext.GetPipelineOutputDirectory();
             string packageOutputDirectory = buildParametersContext.GetPackageOutputDirectory();
             int outputNameStyle = (int)buildParametersContext.Parameters.FileNameStyle;
 
+            // 仅在编辑器下并行构建
+            #if UNITY_EDITOR
+            Parallel.ForEach(buildMapContext.Collection, bundleInfo => {
+                // 1.检测文件名长度
+                {
+                    // NOTE：检测文件名长度不要超过260字符。
+                    string fileName = bundleInfo.BundleName;
+                    if (fileName.Length >= 260) {
+                        string message = BuildLogger.GetErrorMessage(ErrorCode.CharactersOverTheLimit, $"Bundle file name character count exceeds limit : {fileName}");
+                        throw new Exception(message);
+                    }
+                }
+
+                // 2.更新构建输出的文件路径
+                {
+                    bundleInfo.BuildOutputFilePath = $"{pipelineOutputDirectory}/{bundleInfo.BundleName}";
+                    if (bundleInfo.Encrypted)
+                        bundleInfo.PackageSourceFilePath = bundleInfo.EncryptedFilePath;
+                    else
+                        bundleInfo.PackageSourceFilePath = bundleInfo.BuildOutputFilePath;
+                }
+
+                // 3.更新文件其它信息
+                {
+                    bundleInfo.PackageUnityHash = GetUnityHash(bundleInfo, context);
+                    bundleInfo.PackageUnityCRC = GetUnityCRC(bundleInfo, context);
+                    bundleInfo.PackageFileHash = GetBundleFileHash(bundleInfo, buildParametersContext);
+                    bundleInfo.PackageFileCRC = GetBundleFileCRC(bundleInfo, buildParametersContext);
+                    bundleInfo.PackageFileSize = GetBundleFileSize(bundleInfo, buildParametersContext);
+                }
+
+                // 4.更新补丁包输出的文件路径
+                {
+                    string bundleName = bundleInfo.BundleName;
+                    string fileHash = bundleInfo.PackageFileHash;
+                    string fileExtension = ManifestTools.GetRemoteBundleFileExtension(bundleName);
+                    string fileName = ManifestTools.GetRemoteBundleFileName(outputNameStyle, bundleName, fileExtension, fileHash);
+                    bundleInfo.PackageDestFilePath = $"{packageOutputDirectory}/{fileName}";
+                }
+            });
+            #else
             // 1.检测文件名长度
             foreach (var bundleInfo in buildMapContext.Collection)
             {
@@ -58,12 +98,13 @@ namespace YooAsset.Editor
                 string fileName = ManifestTools.GetRemoteBundleFileName(outputNameStyle, bundleName, fileExtension, fileHash);
                 bundleInfo.PackageDestFilePath = $"{packageOutputDirectory}/{fileName}";
             }
+            #endif
         }
 
-        protected abstract string GetUnityHash(BuildBundleInfo bundleInfo, BuildContext context);
-        protected abstract uint GetUnityCRC(BuildBundleInfo bundleInfo, BuildContext context);
+        protected abstract string GetUnityHash(BuildBundleInfo      bundleInfo, BuildContext           context);
+        protected abstract uint   GetUnityCRC(BuildBundleInfo       bundleInfo, BuildContext           context);
         protected abstract string GetBundleFileHash(BuildBundleInfo bundleInfo, BuildParametersContext buildParametersContext);
-        protected abstract string GetBundleFileCRC(BuildBundleInfo bundleInfo, BuildParametersContext buildParametersContext);
-        protected abstract long GetBundleFileSize(BuildBundleInfo bundleInfo, BuildParametersContext buildParametersContext);
+        protected abstract string GetBundleFileCRC(BuildBundleInfo  bundleInfo, BuildParametersContext buildParametersContext);
+        protected abstract long   GetBundleFileSize(BuildBundleInfo bundleInfo, BuildParametersContext buildParametersContext);
     }
 }

--- a/Assets/YooAsset/Runtime/ResourcePackage/ManifestTools.cs
+++ b/Assets/YooAsset/Runtime/ResourcePackage/ManifestTools.cs
@@ -328,6 +328,33 @@ namespace YooAsset
         /// </summary>
         public static string GetRemoteBundleFileName(int nameStyle, string bundleName, string fileExtension, string fileHash)
         {
+            // 编辑器下的 ESBP 会并行调用
+            #if UNITY_EDITOR
+            if (nameStyle == (int)EFileNameStyle.HashName)
+            {
+                return $"{fileHash}{fileExtension}";
+            }
+            else if (nameStyle == (int)EFileNameStyle.BundleName)
+            {
+                return bundleName;
+            }
+            else if (nameStyle == (int)EFileNameStyle.BundleName_HashName)
+            {
+                if (string.IsNullOrEmpty(fileExtension))
+                {
+                    return $"{bundleName}_{fileHash}";
+                }
+                else
+                {
+                    string fileName = bundleName.Remove(bundleName.LastIndexOf('.'));
+                    return $"{fileName}_{fileHash}{fileExtension}";
+                }
+            }
+            else
+            {
+                throw new NotImplementedException($"Invalid name style : {nameStyle}");
+            }
+            #else
             if (nameStyle == (int)EFileNameStyle.HashName)
             {
                 return StringUtility.Format("{0}{1}", fileHash, fileExtension);
@@ -352,6 +379,7 @@ namespace YooAsset
             {
                 throw new NotImplementedException($"Invalid name style : {nameStyle}");
             }
+            #endif
         }
     }
 }


### PR DESCRIPTION
公司项目在 25000 资源数量级的情况下, 经策划反馈每次模拟构建流程过长, 影响工作流程. 经过测试 TaskUpdateBundleInfo.UpdateBundleInfo 方法中的 步骤3.更新文件其它信息, 4.更新补丁包输出的文件路径 都有9秒开销, 并行化并添加宏定义后该开销共减低至2秒且不影响正式打包.